### PR TITLE
extend public API with optional event functions to support additional use-case

### DIFF
--- a/build/mojs-player.js
+++ b/build/mojs-player.js
@@ -404,7 +404,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    var onSeekStart = this._props.onSeekStart;
 
-	    if (onSeekStart) {
+	    if (this._isFunction(onSeekStart)) {
 	      onSeekStart(e);
 	    }
 	  };
@@ -424,7 +424,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      var onSeekEnd = _this2._props.onSeekEnd;
 
-	      if (onSeekEnd) {
+	      if (_this2._isFunction(onSeekEnd)) {
 	        onSeekEnd(e);
 	      }
 	    }, 20);
@@ -604,7 +604,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    var onPlayStateChange = this._props.onPlayStateChange;
 
-	    if (onPlayStateChange) {
+	    if (this._isFunction(onPlayStateChange)) {
 	      onPlayStateChange(isPlay);
 	    }
 	  };
@@ -619,7 +619,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    this._props.isHidden = isHidden;
 	    var onToggleHide = this._props.onToggleHide;
 
-	    if (onToggleHide) {
+	    if (this._isFunction(onToggleHide)) {
 	      onToggleHide(isHidden);
 	    }
 
@@ -724,7 +724,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    var onProgress = this._props.onProgress;
 
-	    if (onProgress) {
+	    if (this._isFunction(onProgress)) {
 	      onProgress(progress);
 	    }
 	  };

--- a/build/mojs-player.js
+++ b/build/mojs-player.js
@@ -175,6 +175,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    this._defaults.name = 'mojs-player';
 	    this._defaults.onToggleHide = null;
 	    this._defaults.onPlayStateChange = null;
+	    this._defaults.onSeekStart = null;
+	    this._defaults.onSeekEnd = null;
 
 	    this.revision = '0.43.16';
 
@@ -398,6 +400,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  MojsPlayer.prototype._onSeekStart = function _onSeekStart(e) {
 	    this._sysTween.pause();
+
+	    var onSeekStart = this._props.onSeekStart;
+
+	    if (onSeekStart) {
+	      onSeekStart(e);
+	    }
 	  };
 	  /*
 	    Method that is invoked when user touches the track.
@@ -412,6 +420,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	    clearTimeout(this._endTimer);
 	    this._endTimer = setTimeout(function () {
 	      _this2._props.isPlaying && _this2._play();
+
+	      var onSeekEnd = _this2._props.onSeekEnd;
+
+	      if (onSeekEnd) {
+	        onSeekEnd(e);
+	      }
 	    }, 20);
 	  };
 	  /*

--- a/build/mojs-player.js
+++ b/build/mojs-player.js
@@ -814,6 +814,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return Math.abs(hash);
 	  };
 
+	  /*
+	    Method to determine if variable is a function
+	    @private
+	    @param {Function} Function to be guarenteed.
+	    @return {Boolean} true/false whether variable reference was a function
+	  */
+
+
+	  MojsPlayer.prototype._isFunction = function _isFunction(fn) {
+	    return typeof fn === 'function';
+	  };
+
 	  return MojsPlayer;
 	}(_module2.default);
 

--- a/build/mojs-player.js
+++ b/build/mojs-player.js
@@ -177,6 +177,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    this._defaults.onPlayStateChange = null;
 	    this._defaults.onSeekStart = null;
 	    this._defaults.onSeekEnd = null;
+	    this._defaults.onProgress = null;
 
 	    this.revision = '0.43.16';
 
@@ -720,6 +721,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	      } while (start + this._props.precision < progress);
 	    }
 	    this.timeline.setProgress(progress);
+
+	    var onProgress = this._props.onProgress;
+
+	    if (onProgress) {
+	      onProgress(progress);
+	    }
 	  };
 	  /*
 	    Method that is invoked on timeline's right bound progress.

--- a/build/mojs-player.js
+++ b/build/mojs-player.js
@@ -174,6 +174,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    this._defaults.precision = 0.1;
 	    this._defaults.name = 'mojs-player';
 	    this._defaults.onToggleHide = null;
+	    this._defaults.onPlayStateChange = null;
 
 	    this.revision = '0.43.16';
 
@@ -584,6 +585,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	      this._play();
 	    } else {
 	      this._sysTween.pause();
+	    }
+
+	    var onPlayStateChange = this._props.onPlayStateChange;
+
+	    if (onPlayStateChange) {
+	      onPlayStateChange(isPlay);
 	    }
 	  };
 	  /*

--- a/js/mojs-player.babel.js
+++ b/js/mojs-player.babel.js
@@ -43,6 +43,7 @@ class MojsPlayer extends Module {
     this._defaults.precision    = 0.1;
     this._defaults.name         = 'mojs-player';
     this._defaults.onToggleHide = null;
+    this._defaults.onPlayStateChange = null;
 
     this.revision = '0.43.16';
 
@@ -393,6 +394,11 @@ class MojsPlayer extends Module {
   _onPlayStateChange ( isPlay ) {
     this._props.isPlaying = isPlay;
     if ( isPlay ) { this._play(); } else { this._sysTween.pause(); }
+
+    const { onPlayStateChange } = this._props;
+    if (onPlayStateChange) {
+      onPlayStateChange(isPlay);
+    }
   }
   /*
     Callback for hide button change state.

--- a/js/mojs-player.babel.js
+++ b/js/mojs-player.babel.js
@@ -252,7 +252,7 @@ class MojsPlayer extends Module {
     this._sysTween.pause();
 
     const { onSeekStart } = this._props;
-    if (onSeekStart) {
+    if (this._isFunction(onSeekStart)) {
       onSeekStart(e);
     }
   }
@@ -267,7 +267,7 @@ class MojsPlayer extends Module {
       this._props.isPlaying &&this._play();
 
       const { onSeekEnd } = this._props;
-      if (onSeekEnd) {
+      if (this._isFunction(onSeekEnd)) {
         onSeekEnd(e);
       }
     }, 20 );
@@ -411,7 +411,7 @@ class MojsPlayer extends Module {
     if ( isPlay ) { this._play(); } else { this._sysTween.pause(); }
 
     const { onPlayStateChange } = this._props;
-    if (onPlayStateChange) {
+    if (this._isFunction(onPlayStateChange)) {
       onPlayStateChange(isPlay);
     }
   }
@@ -423,7 +423,7 @@ class MojsPlayer extends Module {
   _onHideStateChange ( isHidden ) {
     this._props.isHidden = isHidden;
     const { onToggleHide } = this._props;
-    if (onToggleHide) {
+    if (this._isFunction(onToggleHide)) {
       onToggleHide(isHidden);
     }
 
@@ -507,7 +507,7 @@ class MojsPlayer extends Module {
     this.timeline.setProgress( progress );
 
     const { onProgress } = this._props;
-    if (onProgress) {
+    if (this._isFunction(onProgress)) {
       onProgress(progress);
     }
   }
@@ -582,7 +582,7 @@ class MojsPlayer extends Module {
     @param {Function} Function to be guarenteed.
     @return {Boolean} true/false whether variable reference was a function
   */
-  _isFunction (fn) { return typeof fn === 'function' }
+  _isFunction (fn) { return typeof fn === 'function'; }
 }
 
 if ( (typeof define === "function") && define.amd ) {

--- a/js/mojs-player.babel.js
+++ b/js/mojs-player.babel.js
@@ -44,6 +44,8 @@ class MojsPlayer extends Module {
     this._defaults.name         = 'mojs-player';
     this._defaults.onToggleHide = null;
     this._defaults.onPlayStateChange = null;
+    this._defaults.onSeekStart = null;
+    this._defaults.onSeekEnd = null;
 
     this.revision = '0.43.16';
 
@@ -245,7 +247,14 @@ class MojsPlayer extends Module {
     @private
     @param {Object} Original event object.
   */
-  _onSeekStart ( e ) { this._sysTween.pause(); }
+  _onSeekStart ( e ) {
+    this._sysTween.pause();
+
+    const { onSeekStart } = this._props;
+    if (onSeekStart) {
+      onSeekStart(e);
+    }
+  }
   /*
     Method that is invoked when user touches the track.
     @private
@@ -255,6 +264,11 @@ class MojsPlayer extends Module {
     clearTimeout( this._endTimer );
     this._endTimer = setTimeout( () => {
       this._props.isPlaying &&this._play();
+
+      const { onSeekEnd } = this._props;
+      if (onSeekEnd) {
+        onSeekEnd(e);
+      }
     }, 20 );
   }
   /*

--- a/js/mojs-player.babel.js
+++ b/js/mojs-player.babel.js
@@ -46,6 +46,7 @@ class MojsPlayer extends Module {
     this._defaults.onPlayStateChange = null;
     this._defaults.onSeekStart = null;
     this._defaults.onSeekEnd = null;
+    this._defaults.onProgress = null;
 
     this.revision = '0.43.16';
 
@@ -504,6 +505,11 @@ class MojsPlayer extends Module {
       } while ( start + this._props.precision < progress );
     }
     this.timeline.setProgress( progress );
+
+    const { onProgress } = this._props;
+    if (onProgress) {
+      onProgress(progress);
+    }
   }
   /*
     Method that is invoked on timeline's right bound progress.

--- a/js/mojs-player.babel.js
+++ b/js/mojs-player.babel.js
@@ -575,6 +575,14 @@ class MojsPlayer extends Module {
     }
     return Math.abs( hash );
   }
+
+  /*
+    Method to determine if variable is a function
+    @private
+    @param {Function} Function to be guarenteed.
+    @return {Boolean} true/false whether variable reference was a function
+  */
+  _isFunction (fn) { return typeof fn === 'function' }
 }
 
 if ( (typeof define === "function") && define.amd ) {


### PR DESCRIPTION
Hey @legomushroom, thanks for making this.

I added these four optional functions so that I could synchronize an animation over-top a `<video>` element. That is, when I integrate with these elements, I can pause, seek, and play the video, scrub back and forth, etc.

This is done as:

```javascript
const vid = document.querySelector('#vid');

// simple state holder for play/pause
const state = {};

// connect to player
const player = new MojsPlayer({
  add: timeline,
  isPlaying: true,
  isRepeat: true,
  isSaveState: false,
  progress: 0,
  onPlayStateChange: isPlaying => {
    state.isPlaying = isPlaying;
    isPlaying ? vid.play() : vid.pause();
  },
  onSeekStart: () => {
    vid.pause();
    state.seeking = true;
  },
  onSeekEnd: () => {
    if (state.isPlaying) vid.play();
    state.seeking = false;
  },
  onProgress: progress => {
    if (!state.seeking) return;

    // set video time based on scrubber
    vid.currentTime = vid.duration * progress;
  }
});
```

I can DM a gif/vid of the use case if you want to see a justification of the usefulness of these additions.

Thanks for considering.