### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `MojsPlayer` depends on `mojs >= 0.225.2` so make sure you link it first.
 [CDN](https://www.jsdelivr.com/):
 
 ```
-<script src="//cdn.jsdelivr.net/mojs-player/latest/mojs-player.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/mojs-player@latest/build/mojs-player.min.js"></script>
 ```
 
 [NPM](https://www.npmjs.com/):


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/mojs-player.

Feel free to ping me if you have any questions regarding this change.